### PR TITLE
Add Val Town badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Getting started with Cloudflare Workers and Replicate
 
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/)](https://www.val.town/x/stevekrouse/replicate_starter)
+
 This is a template for a simple web app using [Cloudflare Workers](https://developers.cloudflare.com/workers/), [Hono](https://honojs.dev/), and [Replicate](https://replicate.com/) to generate images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell), a fast and high-quality open-source image generation model.
 
 ![screenshot](https://github.com/user-attachments/assets/f123b271-09a1-468c-9aac-5fdd4ed75184)


### PR DESCRIPTION

![Screenshot 2025-02-11 at 17 20 31@2x](https://github.com/user-attachments/assets/53a80af1-7427-4371-84ae-279fb0f9b4e1)


Apologies for the cheekiness of this pull request! Feel free to close it if this is not at all something you want. 

I wanted to submit this PR as food for thought because it worked well [here on Steel's starter app](https://github.com/steel-dev/steel-cookbook/tree/main/examples/steel-puppeteer-starter).

We should probably create a "Replicate" company account on Val Town for this starter to live under. It would seem more polished, and then you guys would properly own it, and be able to update it. Let me know if you agree and I can get this started for you – I just need an email address for the account.

Feedback greatly appreciated! We'll can make any changes you want.